### PR TITLE
Add TSB manifest files for OLM-based operator deployment

### DIFF
--- a/manifests/00-tsb-namespace.yaml
+++ b/manifests/00-tsb-namespace.yaml
@@ -1,0 +1,5 @@
+---
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openshift-template-service-broker

--- a/manifests/01-tsb-catalogsource-configmap.yaml
+++ b/manifests/01-tsb-catalogsource-configmap.yaml
@@ -1,0 +1,262 @@
+---
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: tsb-operator
+  namespace: openshift-operator-lifecycle-manager
+data:
+  customResourceDefinitions: |-
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: templateservicebrokers.osb.openshift.io
+      spec:
+        group: osb.openshift.io
+        names:
+          kind: TemplateServiceBroker
+          listKind: TemplateServiceBrokerList
+          plural: templateservicebrokers
+          singular: templateservicebroker
+        scope: Namespaced
+        version: v1alpha1
+  clusterServiceVersions: |-
+    - apiVersion: operators.coreos.com/v1alpha1
+      kind: ClusterServiceVersion
+      metadata:
+        name: templateservicebrokeroperator.v0.1.0
+        namespace: placeholder
+        annotations:
+          alm-examples: '[{"apiVersion":"osb.openshift.io/v1alpha1","kind":"TemplateServiceBroker","metadata":{"name":"template-service-broker","namespace":"openshift-template-service-broker"},"spec":{"size":3,"version":"3.2.13"}}]'
+      spec:
+        displayName: Template Service Broker Operator
+        description: |
+          The Template Service Broker implements the [Open Service Broker
+          API](https://github.com/openservicebrokerapi/servicebroker/blob/master/spec.md)
+          endpoints:
+
+          - *Catalog*: returns a list of available templates as OSB API
+            *Service* objects (the templates are read from one or more
+            namespaces configured in the master config).
+
+          - *Provision*: provision a given template (referred by its UID) into a
+            namespace.  Under the covers, this creates a non-namespaced
+            **BrokerTemplateInstance** object for the template service broker to
+            store state associated with the the instantiation, as well as the
+            **Secret** and **TemplateInstance** objects which are picked up by
+            the **TemplateInstance** controller.  *Provision* is an asynchronous
+            operation: it may return before provisioning is completed, and the
+            provision status can (must) be recovered via the *Last Operation*
+            endpoint (see below).
+
+          - *Bind*: for a given template, return "credentials" exposed in any
+            created ConfigMap, Secret, Service or Route object (see
+            ExposeAnnotationPrefix and Base64ExposeAnnotationPrefix
+            documentation).  The *Bind* call records the fact that it took
+            place in the appropriate **BrokerTemplateInstance** object.
+
+          - *Unbind*: this simply removes the metadata previously placed in the
+            **BrokerTemplateInstance** object by a *Bind* call.
+
+          - *Deprovision*: removes the objects created by the *Provision* call.
+            The garbage collector removes all additional objects created by the
+            **TemplateInstance** controller, hopefully transitively, as
+            documented above.
+
+          - *Last Operation*: returns the status of the previously run
+            asynchronous operation.  In the template service broker, *Provision*
+            is the only asynchronous operation.
+        keywords: ['template', 'broker', 'open service broker']
+        version: 0.1.0
+        maturity: alpha
+        maintainers:
+        - name: Red Hat, Inc.
+          email: ansible-service-broker@redhat.com
+        provider:
+          name: Red Hat, Inc.
+        labels:
+          alm-status-descriptors: templateservicebrokeroperator.v0.1.0
+          operated-by: templateservicebrokeroperator
+        selector:
+          matchLabels:
+            operated-by: templateservicebrokeroperator
+        links:
+          - name: Documentation
+            url: https://docs.okd.io/latest/architecture/service_catalog/template_service_broker.html
+          - name: Source Code
+            url: https://github.com/openshift/origin/tree/master/pkg/templateservicebroker
+        install:
+          strategy: deployment
+          spec:
+            permissions:
+            - serviceAccountName: template-service-broker-operator
+              rules:
+              - apiGroups:
+                - ""
+                resources:
+                - pods
+                - configmaps
+                - secrets
+                - services
+                verbs:
+                - "*"
+              - apiGroups:
+                - apps
+                resources:
+                - deployments
+                verbs:
+                - "*"
+              - apiGroups:
+                - apps.openshift.io
+                resources:
+                - deploymentconfigs
+                verbs:
+                - "*"
+            clusterPermissions:
+            - serviceAccountName: template-service-broker-operator
+              rules:
+              - apiGroups:
+                - osb.openshift.io
+                resources:
+                - templateservicebrokers
+                verbs:
+                - "*"
+              - apiGroups:
+                - servicecatalog.k8s.io
+                resources:
+                - clusterservicebrokers
+                - servicebrokers
+                verbs:
+                - "*"
+            - serviceAccountName: template-service-broker-client
+              rules:
+              - nonResourceURLs:
+                - /brokers/template.openshift.io/*
+                verbs:
+                - delete
+                - get
+                - put
+                - update
+            - serviceAccountName: apiserver
+              rules:
+              - apiGroups:
+                - authorization.k8s.io
+                resources:
+                - subjectaccessreviews
+                verbs:
+                - create
+              - apiGroups:
+                - authentication.k8s.io
+                resources:
+                - tokenreviews
+                verbs:
+                - create
+              - apiGroups:
+                - authorization.openshift.io
+                resources:
+                - subjectaccessreviews
+                verbs:
+                - create
+              - apiGroups:
+                - template.openshift.io
+                resources:
+                - brokertemplateinstances
+                verbs:
+                - create
+                - delete
+                - get
+                - update
+              - apiGroups:
+                - template.openshift.io
+                resources:
+                - brokertemplateinstances/finalizers
+                verbs:
+                - update
+              - apiGroups:
+                - template.openshift.io
+                resources:
+                - templateinstances
+                verbs:
+                - assign
+                - create
+                - delete
+                - get
+              - apiGroups:
+                - template.openshift.io
+                resources:
+                - templates
+                verbs:
+                - get
+                - list
+                - watch
+              - apiGroups:
+                - ""
+                resources:
+                - secrets
+                verbs:
+                - create
+                - delete
+                - get
+              - apiGroups:
+                - ""
+                resources:
+                - configmaps
+                - services
+                verbs:
+                - get
+              - apiGroups:
+                - ""
+                resources:
+                - routes
+                verbs:
+                - get
+              - apiGroups:
+                - route.openshift.io
+                resources:
+                - routes
+                verbs:
+                - get
+              - apiGroups:
+                - ""
+                resources:
+                - events
+                verbs:
+                - create
+                - patch
+                - update
+            deployments:
+            - name: template-service-broker-operator
+              spec:
+                replicas: 1
+                selector:
+                  matchLabels:
+                    name: template-service-broker-operator-alm-owned
+                template:
+                  metadata:
+                    name: template-service-broker-operator-alm-owned
+                    labels:
+                      name: template-service-broker-operator-alm-owned
+                  spec:
+                    serviceAccountName: template-service-broker-operator
+                    containers:
+                    - name: template-service-broker-operator
+                      image: docker.io/automationbroker/template-service-broker-operator:latest
+                      imagePullPolicy: IfNotPresent
+                      env:
+                      - name: IMAGE
+                        value: docker.io/openshift/origin-template-service-broker:latest
+                      - name: WATCH_NAMESPACE
+                        valueFrom:
+                          fieldRef:
+                            fieldPath: metadata.namespace
+        customresourcedefinitions:
+          owned:
+          - name: templateservicebrokers.osb.openshift.io
+            version: v1alpha1
+            kind: TemplateServiceBroker
+            displayName: Template Service Broker
+            description: An Open Service Broker supporting management of OpenShift templates.
+  packages: |-
+    - packageName: templateservicebroker
+      channels:
+      - name: alpha
+        currentCSV: templateservicebrokeroperator.v0.1.0

--- a/manifests/02-tsb-catalogsource.yaml
+++ b/manifests/02-tsb-catalogsource.yaml
@@ -1,0 +1,10 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: CatalogSource
+metadata:
+  name: tsb-operator
+  namespace: openshift-operator-lifecycle-manager
+spec:
+  configMap: tsb-operator
+  displayName: Template Service Broker
+  publisher: Red Hat
+  sourceType: internal

--- a/manifests/03-tsb-operatorgroup.yaml
+++ b/manifests/03-tsb-operatorgroup.yaml
@@ -1,0 +1,9 @@
+apiVersion: operators.coreos.com/v1alpha2
+kind: OperatorGroup
+metadata:
+  name: template-service-broker
+  namespace: openshift-template-service-broker
+spec:
+  selector:
+    matchLabels:
+      ns: openshift-template-service-broker

--- a/manifests/04-tsb-subscription.yaml
+++ b/manifests/04-tsb-subscription.yaml
@@ -1,0 +1,11 @@
+apiVersion: operators.coreos.com/v1alpha1
+kind: Subscription
+metadata:
+  generateName: templatebroker-
+  namespace: openshift-template-service-broker
+spec:
+  source: tsb-operator
+  name: templatebroker
+  startingCSV: templatebrokeroperator.v0.1.0
+  channel: alpha
+

--- a/manifests/04-tsb-subscription.yaml
+++ b/manifests/04-tsb-subscription.yaml
@@ -6,6 +6,6 @@ metadata:
 spec:
   source: tsb-operator
   name: templatebroker
-  startingCSV: templatebrokeroperator.v0.1.0
+  startingCSV: templateservicebrokeroperator.v0.1.0
   channel: alpha
 

--- a/manifests/05-tsb-cr.yaml
+++ b/manifests/05-tsb-cr.yaml
@@ -1,0 +1,6 @@
+apiVersion: osb.openshift.io/v1alpha1
+kind: TemplateServiceBroker
+metadata:
+  name: template-service-broker
+  namespace: openshift-template-service-broker
+spec: {}


### PR DESCRIPTION
See https://github.com/openshift/ansible-service-broker/pull/1151

Goal is to get these files out of our personal "stuff" repos and into a more official location. Also setting the groundwork in these repos to have an official `manifests` directory that will contain the OperatorBundle yaml to be used by CI builds.