### PR TITLE
wait for CRD to be created, load deployment as file when grabbing logs

### DIFF
--- a/molecule/cluster-olm/playbook.yml
+++ b/molecule/cluster-olm/playbook.yml
@@ -45,7 +45,7 @@
       environment:
         KUBECONFIG: '{{ lookup("env", "KUBECONFIG") }}'
       vars:
-        definition: "{{ lookup('template', '/'.join([deploy_dir, 'operator.yaml'])) | from_yaml }}"
+        definition: "{{ lookup('file', '/'.join([deploy_dir, 'operator.yaml'])) | from_yaml }}"
       register: log
 
     - debug: var=log.stdout_lines

--- a/molecule/cluster-olm/prepare.yml
+++ b/molecule/cluster-olm/prepare.yml
@@ -87,3 +87,8 @@
           name: openshifttemplateservicebroker
           startingCSV: openshifttemplateservicebrokeroperator.v4.1.0
           channel: stable
+
+  - name: Wait for the CRD to be created
+    debug:
+      msg: "Waiting for TemplateServiceBroker CRD to exist..."
+    until: "'osb.openshift.io' in lookup('k8s', cluster_info='api_groups')"

--- a/molecule/cluster/playbook.yml
+++ b/molecule/cluster/playbook.yml
@@ -68,7 +68,7 @@
       environment:
         KUBECONFIG: '{{ lookup("env", "KUBECONFIG") }}'
       vars:
-        definition: "{{ lookup('template', '/'.join([deploy_dir, 'testing', 'operator.yaml.j2'])) | from_yaml }}"
+        definition: "{{ lookup('file', '/'.join([deploy_dir, 'testing', 'operator.yaml.j2'])) | from_yaml }}"
       register: log
 
     - debug: var=log.stdout_lines

--- a/molecule/cluster/verify.yml
+++ b/molecule/cluster/verify.yml
@@ -309,5 +309,3 @@
 
       - fail:
           msg: "Failed in asserts.yml"
-
-


### PR DESCRIPTION
This should fix/make transparent some CI errors.