### PR TITLE
Bug 1793369: apply permission fix in the etc/pwd [release 4.1]

### DIFF
--- a/build/custom-ci-build-root.Dockerfile
+++ b/build/custom-ci-build-root.Dockerfile
@@ -11,5 +11,3 @@ RUN pip install -U setuptools \
  && pip install molecule==2.20.1 jmespath 'openshift>=0.8.0, < 0.9.0' \
  && pip install -U requests
 
-
-RUN chmod g+rw /etc/passwd


### PR DESCRIPTION
**Description**
- Fix permission for `/etc/passwd`

Requires: https://github.com/openshift/template-service-broker-operator/pull/93 ( to fix the build ) 
