### PR TITLE
Fix CI - release-4.2 

### DIFF
--- a/build/custom-ci-build-root.Dockerfile
+++ b/build/custom-ci-build-root.Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/origin-release:golang-1.10
+FROM openshift/origin-release:golang-1.12
 
 RUN yum install -y epel-release \
     && yum install -y python-devel python-pip gcc
@@ -7,8 +7,8 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.13.0/b
  && install kubectl /usr/local/bin/kubectl \
  && rm -f kubectl
 
-RUN pip install -U setuptools \
- && pip install molecule==2.20.1 jmespath 'openshift>=0.8.0, < 0.9.0' \
+RUN pip install -U setuptools wheel \
+ && pip install -U more-itertools==7.0.0 molecule==2.20.1 jmespath 'openshift>=0.8.0, < 0.9.0' \
  && pip install -U requests
 
 


### PR DESCRIPTION
**Description**
Fix the build of the image. Note that the CI uses the branch source code instead of PR and because of this it still not passing. See:


```
2020/03/27 17:54:08 Tagged shared images from ocp/4.2:${component}, images will be pullable from default-route-openshift-image-registry.apps.build01.ci.devcluster.openshift.com/ci-op-vh443z7m/stable:${component}
2020/03/27 17:54:08 waiting for importing pipeline:ansible_operator ...
2020/03/27 17:55:59 Build root failed, printing logs:
Cloning "https://github.com/openshift/template-service-broker-operator.git" ...
	Commit:	6662db1ea3b0150d98775db608359c14bd78f669 (Add service instance creation to the tests (#56))
	Author:	Fabian von Feilitzsch <fabian@fabianism.us>
	Date:	Tue Aug 6 12:48:39 2019 -0400
Caching blobs under "/var/cache/blobs".

```