### PR TITLE
FIX CI - release-4.1

### DIFF
--- a/build/custom-ci-build-root.Dockerfile
+++ b/build/custom-ci-build-root.Dockerfile
@@ -1,4 +1,4 @@
-FROM openshift/origin-release:golang-1.10
+FROM openshift/origin-release:golang-1.12
 
 RUN yum install -y epel-release \
     && yum install -y python-devel python-pip gcc
@@ -7,8 +7,8 @@ RUN curl -LO https://storage.googleapis.com/kubernetes-release/release/v1.13.0/b
  && install kubectl /usr/local/bin/kubectl \
  && rm -f kubectl
 
-RUN pip install -U setuptools \
- && pip install molecule==2.20.1 jmespath 'openshift>=0.8.0, < 0.9.0' \
+RUN pip install -U setuptools wheel \
+ && pip install -U more-itertools==7.0.0 molecule==2.20.1 jmespath 'openshift>=0.8.0, < 0.9.0' \
  && pip install -U requests
 
 


### PR DESCRIPTION
**Description**
Fix the build of the image. Note that the CI uses the branch source code instead of PR and because of this it still not passing. See:


```
2020/03/27 15:30:00 Build root failed, printing logs:
Cloning "https://github.com/openshift/template-service-broker-operator.git" ...
	Commit:	57cdaef796081369d8f2911b1284823a8140229f (adding ability to remove cluster scoped resources on deletion (#49) (#50))
	Author:	Shawn Hurley <shurley@redhat.com>
	Date:	Thu Sep 26 22:05:54 2019 -0400
Caching blobs under "/var/cache/blobs".
```