### PR TITLE
Bug 1782061: Allow the PrometheusAlert to fire.

### DIFF
--- a/deploy/namespace.yaml
+++ b/deploy/namespace.yaml
@@ -3,3 +3,5 @@ apiVersion: v1
 kind: Namespace
 metadata:
   name: openshift-template-service-broker
+  labels:
+    openshift.io/cluster-monitoring: "true"

--- a/deploy/olm-catalog/openshift-template-service-broker-manifests/4.3/openshifttemplateservicebrokeroperator.v4.3.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/openshift-template-service-broker-manifests/4.3/openshifttemplateservicebrokeroperator.v4.3.0.clusterserviceversion.yaml
@@ -130,6 +130,8 @@ spec:
         - apiGroups:
           - rbac.authorization.k8s.io
           resources:
+          - roles
+          - rolebindings
           - clusterroles
           - clusterrolebindings
           verbs:
@@ -138,6 +140,7 @@ spec:
           - patch
           - get
           - list
+          - watch
         - apiGroups:
           - authorization.k8s.io
           resources:

--- a/deploy/olm-catalog/openshift-template-service-broker-manifests/4.4/openshifttemplateservicebrokeroperator.v4.4.0.clusterserviceversion.yaml
+++ b/deploy/olm-catalog/openshift-template-service-broker-manifests/4.4/openshifttemplateservicebrokeroperator.v4.4.0.clusterserviceversion.yaml
@@ -130,6 +130,8 @@ spec:
         - apiGroups:
           - rbac.authorization.k8s.io
           resources:
+          - roles
+          - rolebindings
           - clusterroles
           - clusterrolebindings
           verbs:
@@ -138,6 +140,7 @@ spec:
           - patch
           - get
           - list
+          - watch
         - apiGroups:
           - authorization.k8s.io
           resources:

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -48,6 +48,8 @@ rules:
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
+  - roles
+  - rolebindings
   - clusterroles
   - clusterrolebindings
   verbs:
@@ -62,6 +64,8 @@ rules:
 - apiGroups:
   - servicecatalog.k8s.io
   resources:
+  - roles
+  - rolebindings
   - clusterservicebrokers
   - servicebrokers
   verbs:

--- a/deploy/testing/role.yaml.j2
+++ b/deploy/testing/role.yaml.j2
@@ -15,6 +15,8 @@ rules:
   - services
   - services/finalizers
   - serviceaccounts
+  - endpoints
+  - events
   verbs:
   - "*"
 - apiGroups:
@@ -38,6 +40,15 @@ rules:
   - servicemonitors
   verbs:
   - '*'
+- apiGroups:
+  - rbac.authorization.k8s.io
+  resources:
+  - roles
+  - rolebindings
+  - clusterroles
+  - clusterrolebindings
+  verbs:
+  - "*"
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1
@@ -48,6 +59,8 @@ rules:
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:
+  - roles
+  - rolebindings
   - clusterroles
   - clusterrolebindings
   verbs:
@@ -66,6 +79,29 @@ rules:
   - servicebrokers
   verbs:
   - "*"
+
+# Template Service Broker Client
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: template-service-broker-client
+rules:
+- nonResourceURLs:
+  - /brokers/template.openshift.io/*
+  verbs:
+  - delete
+  - get
+  - put
+  - update
+
+# APIServer
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: template-service-broker-apiserver
+rules:
 - apiGroups:
   - authorization.k8s.io
   resources:

--- a/deploy/testing/role_binding.yaml.j2
+++ b/deploy/testing/role_binding.yaml.j2
@@ -26,3 +26,33 @@ roleRef:
   kind: ClusterRole
   name: template-service-broker-operator
   apiGroup: rbac.authorization.k8s.io
+
+# Template Service Broker Client
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: template-service-broker-client
+subjects:
+- kind: ServiceAccount
+  name: template-service-broker-client
+  namespace: '{{ namespace }}'
+roleRef:
+  kind: ClusterRole
+  name: template-service-broker-client
+  apiGroup: rbac.authorization.k8s.io
+
+# APIServer
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: template-service-broker-apiserver
+subjects:
+- kind: ServiceAccount
+  name: apiserver
+  namespace: '{{ namespace }}'
+roleRef:
+  kind: ClusterRole
+  name: template-service-broker-apiserver
+  apiGroup: rbac.authorization.k8s.io

--- a/roles/template-service-broker/defaults/main.yml
+++ b/roles/template-service-broker/defaults/main.yml
@@ -4,6 +4,8 @@ state: present
 kube_system_namespace: kube-system
 broker_name: template-service-broker
 broker_namespace: openshift-template-service-broker
+broker_operator_name: '{{ broker_name }}-operator'
+broker_operator_service_monitor_name: '{{ broker_operator_name }}'
 broker_image: docker.io/openshift/origin-template-service-broker:latest
 broker_log_level: '0'
 broker_node_selector: ""

--- a/roles/template-service-broker/tasks/main.yml
+++ b/roles/template-service-broker/tasks/main.yml
@@ -24,6 +24,9 @@
     - name: tsb-client.clusterrole.yaml
     - name: tsb-client.clusterrolebinding.yaml
     - name: tsb-client.secret.yaml
+    - name: tsb-operator.service-monitor.yaml
+    - name: tsb-operator.monitor-role.yaml
+    - name: tsb-operator.monitor-rolebinding.yaml
     - name: tsb.prometheus-alert.yaml
 
 - name: "Set tsb config map state={{ state }}"

--- a/roles/template-service-broker/templates/tsb-operator.monitor-role.yaml
+++ b/roles/template-service-broker/templates/tsb-operator.monitor-role.yaml
@@ -1,0 +1,16 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ broker_operator_name }}-prom-k8s
+  namespace: {{ broker_namespace }}
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch

--- a/roles/template-service-broker/templates/tsb-operator.monitor-rolebinding.yaml
+++ b/roles/template-service-broker/templates/tsb-operator.monitor-rolebinding.yaml
@@ -1,0 +1,13 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ broker_operator_name }}-prom-k8s
+  namespace: {{ broker_namespace }}
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: {{ broker_operator_name }}-prom-k8s
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring

--- a/roles/template-service-broker/templates/tsb-operator.service-monitor.yaml
+++ b/roles/template-service-broker/templates/tsb-operator.service-monitor.yaml
@@ -1,0 +1,26 @@
+---
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ broker_operator_service_monitor_name }}
+  namespace: {{ broker_namespace }}
+spec:
+  endpoints:
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    port: http-metrics
+    scheme: http
+    tlsConfig:
+      insecureSkipVerify: true
+  - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
+    interval: 30s
+    port: cr-metrics
+    scheme: http
+    tlsConfig:
+      insecureSkipVerify: true
+  namespaceSelector:
+    matchNames:
+    - {{ broker_namespace }}
+  selector:
+    matchLabels:
+      name: openshift-template-service-broker-operator


### PR DESCRIPTION
The PrometheusAlert would no fire because the metrics were not properly
configured. Adding proper Role, Rolebinding and ServiceMonitors to allow
the metrics to be exposed for the Alert to fire.